### PR TITLE
DM-5879 Remove use of Boost smart pointers throughout the Science Pipelines

### DIFF
--- a/src/EdgeRolloffFunctor.cc
+++ b/src/EdgeRolloffFunctor.cc
@@ -23,7 +23,7 @@
  */
 
 #include <cmath>
-#include "boost/make_shared.hpp"
+#include <memory>
 #include "lsst/obs/lsstSim/EdgeRolloffFunctor.h"
 
 namespace lsst {

--- a/src/EdgeRolloffFunctor.cc
+++ b/src/EdgeRolloffFunctor.cc
@@ -37,7 +37,7 @@ EdgeRolloffFunctor::EdgeRolloffFunctor(double amplitude, double scale,
 }
 
 PTR(afw::geom::Functor) EdgeRolloffFunctor::clone() const {
-   return boost::make_shared<EdgeRolloffFunctor>(_amplitude, _scale, _width);
+   return std::make_shared<EdgeRolloffFunctor>(_amplitude, _scale, _width);
 }
 
 double EdgeRolloffFunctor::operator()(double x) const {


### PR DESCRIPTION
Makes the following replacements:

- boost::scoped_ptr -> std::unique_ptr
- boost::shared_ptr -> std::shared_ptr
- boost::weak_ptr -> std::weak_ptr
- boost::static_pointer_cast -> std::static_pointer_cast
- boost::dynamic_pointer_cast -> std::dynamic_pointer_cast
- boost::const_pointer_cast -> std::const_pointer_cast
- boost::reinterpret_pointer_cast -> std::reinterpret_pointer_cast
- boost::enamble_shared_from_this -> std::enable_shared_from_this
- boost pointer related includes -> standard library memory
