### PR TITLE
Remove IngestIndexedReferenceTask_config

### DIFF
--- a/policy/LsstSimMapper.paf
+++ b/policy/LsstSimMapper.paf
@@ -692,12 +692,6 @@ datasets: {
         storage:       "BoostStorage"
         tables:        raw
     }
-    IngestIndexedReferenceTask_config: {
-        template:      "config/IngestIndexedReferenceTask.py"
-        python:        "lsst.pipe.tasks.indexReferenceTask.IngestIndexedReferenceConfig"
-        persistable:   "Config"
-        storage:       "ConfigStorage"
-    }
     cal_ref_cat: {
         persistable: SourceCatalog
         python: lsst.afw.table.SourceCatalog


### PR DESCRIPTION
Remove IngestIndexedReferenceTask_config from LsstSimMapper.paf
in order to use the standard version in daf_butlerUtils