### PR TITLE
Update mysqlpython to python_mysqlclient

### DIFF
--- a/ups/obs_lsstSim.table
+++ b/ups/obs_lsstSim.table
@@ -6,7 +6,7 @@ setupRequired(daf_butlerUtils)
 setupRequired(meas_algorithms)
 setupRequired(ip_isr)
 setupRequired(pipe_tasks)
-setupRequired(mysqlpython)
+setupRequired(python_mysqlclient)
 setupRequired(utils)
 
 envPrepend(LD_LIBRARY_PATH, ${PRODUCT_DIR}/lib)


### PR DESCRIPTION
This will allow obs_lsstSim to use updated mysqlclient which supports python 3