### PR TITLE
DM-13096: Set better default weather for simulations.

### DIFF
--- a/python/lsst/obs/lsstSim/makeLsstSimRawVisitInfo.py
+++ b/python/lsst/obs/lsstSim/makeLsstSimRawVisitInfo.py
@@ -26,6 +26,7 @@ from __future__ import print_function
 from lsst.afw.image import VisitInfo, RotType
 from lsst.afw.geom import degrees
 from lsst.afw.coord import Coord, IcrsCoord, Observatory, Weather
+from lsst.afw.coord.refraction import defaultWeather
 from lsst.obs.base import MakeRawVisitInfo
 
 __all__ = ["MakeLsstSimRawVisitInfo"]
@@ -62,11 +63,13 @@ class MakeLsstSimRawVisitInfo(MakeRawVisitInfo):
         argDict["boresightRotAngle"] = -self.popAngle(md, "ROTANG")
         argDict["rotType"] = RotType.SKY
         argDict["observatory"] = self.observatory
-        argDict["weather"] = Weather(
-            self.popFloat(md, "TEMPERA"),
-            self.pascalFromMmHg(self.popFloat(md, "PRESS")),
-            float("nan"),
-        )
+        weather = defaultWeather(self.observatory.getElevation())
+        temperature = self.defaultMetadata(self.popFloat(md, "TEMPERA"), weather.getAirTemperature(),
+                                           minimum=-10, maximum=40.)
+        pressure = self.defaultMetadata(self.pascalFromMmHg(self.popFloat(md, "PRESS")),
+                                        weather.getAirPressure(), minimum=50000., maximum=90000.)
+        humidity = 40.  # Not currently supplied by phosim, so set to a typical value.
+        argDict["weather"] = Weather(temperature, pressure, humidity)
         # phosim doesn't supply LST, HA, or UT1, and the alt/az/ra/dec/time can be inconsistent.
         # We will leave ERA as NaN until a better answer is available.
         return VisitInfo(**argDict)

--- a/tests/test_getEimage.py
+++ b/tests/test_getEimage.py
@@ -116,10 +116,11 @@ class GetEimageTestCase(lsst.utils.tests.TestCase):
             humid_bool = np.isnan(w1.getHumidity()) and np.isnan(w2.getHumidity())
             if not humid_bool:
                 humid_bool = (w1.getHumidity() == w2.getHumidity())
-            self.assertTrue(w1.getAirPressure() == w2.getAirPressure() and w1.getAirTemperature() ==
-                            w2.getAirTemperature() and humid_bool)
+            self.assertEqual(w1.getAirTemperature(), w2.getAirTemperature())
+            self.assertEqual(w1.getAirPressure(), w2.getAirPressure())
+            self.assertTrue(humid_bool)
 
-        weather = Weather(20, 69327.64145580001, np.nan)
+        weather = Weather(20, 69327.64145580001, 40.)
         test_weather(weather, self.visit_info.getWeather())
 
 

--- a/tests/test_getRaw.py
+++ b/tests/test_getRaw.py
@@ -53,6 +53,7 @@ class GetRawTestCase(lsst.utils.tests.TestCase):
         self.obs_elevation = 2663.0
         self.weath_airTemperature = 5.0
         self.weath_airPressure = MakeRawVisitInfo.pascalFromMmHg(520.0)
+        self.weath_humidity = 40.
 
     def tearDown(self):
         del self.butler
@@ -88,7 +89,7 @@ class GetRawTestCase(lsst.utils.tests.TestCase):
         weather = visitInfo.getWeather()
         self.assertAlmostEqual(weather.getAirTemperature(), self.weath_airTemperature)
         self.assertAlmostEqual(weather.getAirPressure(), self.weath_airPressure)
-        self.assertTrue(math.isnan(weather.getHumidity()))
+        self.assertAlmostEqual(weather.getHumidity(), self.weath_humidity)
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
Simulated data often has invalid weather information, which leads to NANs when calculating refraction. This change ensures the weather parameters are always set within a valid range, and not NAN.