### PR TITLE
DM-13162: Remove duplicate call to `_standardizeExposure` and fix warning.

### DIFF
--- a/python/lsst/obs/lsstSim/lsstSimMapper.py
+++ b/python/lsst/obs/lsstSim/lsstSimMapper.py
@@ -287,12 +287,7 @@ class LsstSimMapper(CameraMapper):
 
     def std_eimage(self, item, dataId):
         """Standardize a eimage dataset by converting it to an Exposure instead of an Image"""
-        exposure = obsBase.exposureFromImage(item, logger=self.log)
-        exposureId = self._computeCcdExposureId(dataId)
-        md = exposure.getMetadata()
-        visitInfo = self.makeRawVisitInfo(md=md, exposureId=exposureId)
-        exposure.getInfo().setVisitInfo(visitInfo)
-        return self._standardizeExposure(self.exposures['eimage'], exposure, dataId, trimmed=True)
+        return self._standardizeExposure(self.exposures['eimage'], item, dataId, trimmed=True)
 
 ###############################################################################
 


### PR DESCRIPTION
`processEimage.py` currently loads the metadata of a simulated observation twice and runs the same code both times, except it only provides a mapper the second time. This generates a warning the first time the code is run, and is unnecessary because the second call provides the correct exposure with VisitInfo.