### PR TITLE
DM-2639: {{Standardize primary method names, run/runDataRef, across PipeTasks}}

### DIFF
--- a/bin.src/processCalibLsstSim.py
+++ b/bin.src/processCalibLsstSim.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
 
     for k in sensorDataRefLists:
         try:
-            task.run(sensorDataRefLists[k], type)
+            task.runDataRef(sensorDataRefLists[k], type)
         except Exception as e:
             task.log.fatal("Failed on dataId=%s: %s", k, e)
             traceback.print_exc(file=sys.stderr)

--- a/python/lsst/obs/lsstSim/processCalibLsstSim.py
+++ b/python/lsst/obs/lsstSim/processCalibLsstSim.py
@@ -63,7 +63,7 @@ class ProcessCalibLsstSimTask(IsrTask):
         self.isr = isr
 
     @pipeBase.timeMethod
-    def run(self, sensorRefList, calibType):
+    def runDataRef(self, sensorRefList, calibType):
         """Process a calibration frame.
 
         @param sensorRef: sensor-level butler data reference


### PR DESCRIPTION
Rename methods according to RFC-352.
Fifteen total repositories with changes.
