### PR TITLE
DM-6640: IsrTask is not a valid CmdLineTask

### DIFF
--- a/config/isr.py
+++ b/config/isr.py
@@ -1,0 +1,5 @@
+"""
+LSST Sim-specific overrides for IsrTask
+"""
+config.doFlat = False
+

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -1,9 +1,16 @@
-"""lsstSim-specific overrides for the processCcd task
 """
-from __future__ import print_function
+LSST Sim-specific overrides for the ProcessCcdTask
+"""
+import os.path
+
+from lsst.utils import getPackageDir
 from lsst.obs.lsstSim import LsstSimIsrTask
 
+obsConfigDir = os.path.join(getPackageDir("obs_lsstSim"), "config"))
+
 config.isr.retarget(LsstSimIsrTask)
+config.isr.load(os.path.join(obsConfigDir, "isr.py")
+
 # this was the default prior to DM-11521.  New default is 2000.
 config.calibrate.deblend.maxFootprintSize=0
 

--- a/config/runIsr.py
+++ b/config/runIsr.py
@@ -1,0 +1,12 @@
+"""
+LSST Sim-specific overrides for RunIsrTask
+"""
+import os.path
+
+from lsst.utils import getPackageDir
+from lsst.obs.lsstSim.lsstSimIsrTask import LsstSimIsrTask
+
+obsConfigDir = os.path.join(getPackageDir("obs_lsstSim"), "config")
+
+config.isr.retarget(LsstSimIsrTask)
+config.isr.load(os.path.join(obsConfigDir, "isr.py"))


### PR DESCRIPTION
This ticket adds a stand-alone runIsr.py script, as well as ensuring that runIsr.py and processCcd.py read the same ISR configuration files.
