### PR TITLE
DM-18610: Add fields, limited mutability, and trim/assembly-state tracking to cameraGeom

### DIFF
--- a/config/isr.py
+++ b/config/isr.py
@@ -2,4 +2,5 @@
 LSST Sim-specific overrides for IsrTask
 """
 config.doFlat = False
+config.doLinearize = False
 

--- a/python/lsst/obs/lsstSim/lsstSimMapper.py
+++ b/python/lsst/obs/lsstSim/lsstSimMapper.py
@@ -293,6 +293,9 @@ class LsstSimMapper(CameraMapper):
                                          dataId, self,
                                          storage=self.rootStorage)
 
+    def map_linearizer(self, dataId, write=False):
+        return None
+
     def bypass_defects(self, datasetType, pythonType, butlerLocation, dataId):
         """Return a defect based on the butler location returned by map_defects
 

--- a/tests/test_lsstSimIsrTask.py
+++ b/tests/test_lsstSimIsrTask.py
@@ -55,6 +55,7 @@ class LsstSimIsrTaskTestCase(unittest.TestCase):
         config.doFringe = False
         config.doAssembleCcd = False
         config.doSnapCombine = False
+        config.doLinearize = False
         lsstIsrTask = LsstSimIsrTask(config=config)
         exposure = lsstIsrTask.runDataRef(self.ampRef).exposure
         self.assertAlmostEqual(afwMath.makeStatistics(exposure.getMaskedImage(), afwMath.MEAN).getValue(),
@@ -70,6 +71,7 @@ class LsstSimIsrTaskTestCase(unittest.TestCase):
         config.doFringe = False
         config.doAssembleCcd = False
         config.doSnapCombine = False
+        config.doLinearize = False
         lsstIsrTask = LsstSimIsrTask(config=config)
         ampExp = self.ampRef.get('raw')
         camera = self.ampRef.get("camera")


### PR DESCRIPTION
Disable isr.doLinearize to prevent failures.
Update to use cameraGeom Builders()/remove ampInfoTables.